### PR TITLE
Build jni sources to single file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,7 @@ task processJavacpp(type: JavaExec) {
   main = 'org.bytedeco.javacpp.tools.Builder'
   args = [
     '-cp', nanodbcJavaOutputs.join(File.pathSeparator),
+    '-o', 'jninanodbc',
     '-Xcompiler', "${nanodbcPath}\\Release\\nanodbc.lib",
     '-Xcompiler', "${nanodbcExtPath}\\Release\\nanodbc_ext.lib",
     '-Xcompiler', 'odbc32.lib',

--- a/src/main/java/io/nanodbc/impl/NativeConnection.java
+++ b/src/main/java/io/nanodbc/impl/NativeConnection.java
@@ -8,7 +8,7 @@ import org.bytedeco.javacpp.annotation.Platform;
 
 import io.nanodbc.Connection;
 
-@Platform(include = "nanodbc_ext.h")
+@Platform(include = "nanodbc_ext.h", library = "jninanodbc")
 @Namespace("nanodbc")
 @Name("connection")
 public class NativeConnection extends Pointer implements Connection {

--- a/src/main/java/io/nanodbc/impl/NativeDate.java
+++ b/src/main/java/io/nanodbc/impl/NativeDate.java
@@ -10,7 +10,7 @@ import org.bytedeco.javacpp.annotation.Name;
 import org.bytedeco.javacpp.annotation.Namespace;
 import org.bytedeco.javacpp.annotation.Platform;
 
-@Platform(include = "nanodbc_ext.h")
+@Platform(include = "nanodbc_ext.h", library = "jninanodbc")
 @Namespace("nanodbc")
 @Name("date")
 class NativeDate extends Pointer {

--- a/src/main/java/io/nanodbc/impl/NativeDateTime.java
+++ b/src/main/java/io/nanodbc/impl/NativeDateTime.java
@@ -10,7 +10,7 @@ import org.bytedeco.javacpp.annotation.Name;
 import org.bytedeco.javacpp.annotation.Namespace;
 import org.bytedeco.javacpp.annotation.Platform;
 
-@Platform(include = "nanodbc_ext.h")
+@Platform(include = "nanodbc_ext.h", library = "jninanodbc")
 @Namespace("nanodbc")
 @Name("timestamp")
 class NativeDateTime extends Pointer {

--- a/src/main/java/io/nanodbc/impl/NativeResult.java
+++ b/src/main/java/io/nanodbc/impl/NativeResult.java
@@ -15,7 +15,7 @@ import org.bytedeco.javacpp.annotation.StdString;
 
 import io.nanodbc.Result;
 
-@Platform(include = "nanodbc_ext.h")
+@Platform(include = "nanodbc_ext.h", library = "jninanodbc")
 @Namespace("nanodbc")
 @Name("result")
 public class NativeResult extends Pointer implements Result {

--- a/src/main/java/io/nanodbc/impl/NativeStatement.java
+++ b/src/main/java/io/nanodbc/impl/NativeStatement.java
@@ -20,7 +20,7 @@ import org.bytedeco.javacpp.annotation.Platform;
 
 import io.nanodbc.Statement;
 
-@Platform(include = "nanodbc_ext.h")
+@Platform(include = "nanodbc_ext.h", library = "jninanodbc")
 @Namespace("nanodbc")
 @Name("statement")
 class NativeStatement extends Pointer implements Statement {

--- a/src/main/java/io/nanodbc/impl/NativeTime.java
+++ b/src/main/java/io/nanodbc/impl/NativeTime.java
@@ -10,7 +10,7 @@ import org.bytedeco.javacpp.annotation.Name;
 import org.bytedeco.javacpp.annotation.Namespace;
 import org.bytedeco.javacpp.annotation.Platform;
 
-@Platform(include = "nanodbc_ext.h")
+@Platform(include = "nanodbc_ext.h", library = "jninanodbc")
 @Namespace("nanodbc")
 @Name("time")
 class NativeTime extends Pointer {

--- a/src/main/java/io/nanodbc/impl/NativeUtil.java
+++ b/src/main/java/io/nanodbc/impl/NativeUtil.java
@@ -5,7 +5,7 @@ import org.bytedeco.javacpp.annotation.ByRef;
 import org.bytedeco.javacpp.annotation.Namespace;
 import org.bytedeco.javacpp.annotation.Platform;
 
-@Platform(include = "nanodbc_ext.h")
+@Platform(include = "nanodbc_ext.h", library = "jninanodbc")
 @Namespace("nanodbc")
 class NativeUtil {
     static {


### PR DESCRIPTION
This reduces the number of bundled DLLs to one and decreases the size of the jar.