### PR TITLE
Remove batch operations parameters

### DIFF
--- a/nanodbc_ext/nanodbc_ext.cpp
+++ b/nanodbc_ext/nanodbc_ext.cpp
@@ -3,14 +3,14 @@
 namespace nanodbc
 {
 
-void execute(result& result, connection& conn, const string& query, long batch_operations, long timeout)
+void execute(result& result, connection& conn, const string& query, long timeout)
 {
-    result = execute(conn, query, batch_operations, timeout);
+    result = execute(conn, query, 1, timeout);
 }
 
-void execute(result& result, statement& stmt, long batch_operations)
+void execute(result& result, statement& stmt)
 {
-    result = execute(stmt, batch_operations);
+    result = execute(stmt);
 }
 
 }

--- a/nanodbc_ext/nanodbc_ext.h
+++ b/nanodbc_ext/nanodbc_ext.h
@@ -7,12 +7,10 @@ void execute(
     result& result,
     connection& conn,
     const string& query,
-    long batch_operations = 1,
     long timeout = 0);
 
 void execute(
     result& result,
-    statement& stmt,
-    long batch_operations = 1);
+    statement& stmt);
 
 }

--- a/src/main/java/io/nanodbc/Connection.java
+++ b/src/main/java/io/nanodbc/Connection.java
@@ -10,7 +10,7 @@ public interface Connection extends AutoCloseable {
 
     void disconnect();
 
-    Result execute(String query, long batchOperations, long timeout);
+    Result execute(String query, long timeout);
 
     Statement prepare(String query, long timeout);
 

--- a/src/main/java/io/nanodbc/Statement.java
+++ b/src/main/java/io/nanodbc/Statement.java
@@ -22,7 +22,7 @@ public interface Statement extends AutoCloseable {
 
     void bindNull(short column);
 
-    Result execute(long batchOperations);
+    Result execute();
 
     @Override
     void close();

--- a/src/main/java/io/nanodbc/impl/NativeConnection.java
+++ b/src/main/java/io/nanodbc/impl/NativeConnection.java
@@ -47,9 +47,9 @@ public class NativeConnection extends Pointer implements Connection {
     public native void disconnect();
 
     @Override
-    public NativeResult execute(String query, long batchOperations, long timeout) {
+    public NativeResult execute(String query, long timeout) {
         NativeResult result = new NativeResult();
-        NativeUtil.execute(result, this, query, batchOperations, timeout);
+        NativeExt.execute(result, this, query, timeout);
         return result;
     }
 

--- a/src/main/java/io/nanodbc/impl/NativeExt.java
+++ b/src/main/java/io/nanodbc/impl/NativeExt.java
@@ -7,14 +7,13 @@ import org.bytedeco.javacpp.annotation.Platform;
 
 @Platform(include = "nanodbc_ext.h", library = "jninanodbc")
 @Namespace("nanodbc")
-class NativeUtil {
+class NativeExt {
     static {
         Loader.load();
     }
 
-    static native void execute(@ByRef NativeResult result, @ByRef NativeConnection conn, String query,
-            long batchOperations, long timeout);
+    static native void execute(@ByRef NativeResult result, @ByRef NativeConnection conn, String query, long timeout);
 
-    static native void execute(@ByRef NativeResult result, @ByRef NativeStatement statement, long batchOperations);
+    static native void execute(@ByRef NativeResult result, @ByRef NativeStatement statement);
 
 }

--- a/src/main/java/io/nanodbc/impl/NativeStatement.java
+++ b/src/main/java/io/nanodbc/impl/NativeStatement.java
@@ -119,9 +119,9 @@ class NativeStatement extends Pointer implements Statement {
     public native void bindNull(short column);
 
     @Override
-    public NativeResult execute(long batchOperations) {
+    public NativeResult execute() {
         NativeResult result = new NativeResult();
-        NativeUtil.execute(result, this, batchOperations);
+        NativeExt.execute(result, this);
         return result;
     }
 


### PR DESCRIPTION
The `batchOperations` parameters aren't valuable since this library doesn't support batch operations.