### PR TITLE
Add no-timeout connection methods

### DIFF
--- a/src/main/java/io/nanodbc/Connection.java
+++ b/src/main/java/io/nanodbc/Connection.java
@@ -2,6 +2,8 @@ package io.nanodbc;
 
 public interface Connection extends AutoCloseable {
 
+    void connect(String connectionString);
+
     void connect(String connectionString, long timeout);
 
     void connect(String dsn, String user, String pass, long timeout);
@@ -10,7 +12,11 @@ public interface Connection extends AutoCloseable {
 
     void disconnect();
 
+    Result execute(String query);
+
     Result execute(String query, long timeout);
+
+    Statement prepare(String query);
 
     Statement prepare(String query, long timeout);
 

--- a/src/main/java/io/nanodbc/Nanodbc.java
+++ b/src/main/java/io/nanodbc/Nanodbc.java
@@ -8,6 +8,10 @@ public class Nanodbc {
         return new NativeConnection();
     }
 
+    public static Connection newConnection(String connectionString) {
+        return new NativeConnection(connectionString);
+    }
+
     public static Connection newConnection(String connectionString, long timeout) {
         return new NativeConnection(connectionString, timeout);
     }

--- a/src/main/java/io/nanodbc/impl/NativeConnection.java
+++ b/src/main/java/io/nanodbc/impl/NativeConnection.java
@@ -20,6 +20,10 @@ public class NativeConnection extends Pointer implements Connection {
         allocate();
     }
 
+    public NativeConnection(String connectionString) {
+        allocate(connectionString);
+    }
+
     public NativeConnection(String connectionString, long timeout) {
         allocate(connectionString, timeout);
     }
@@ -30,9 +34,14 @@ public class NativeConnection extends Pointer implements Connection {
 
     private native void allocate();
 
+    private native void allocate(String connectionString);
+
     private native void allocate(String connectionString, long timeout);
 
     private native void allocate(String dsn, String user, String pass, long timeout);
+
+    @Override
+    public native void connect(String connectionString);
 
     @Override
     public native void connect(String connectionString, long timeout);
@@ -47,10 +56,22 @@ public class NativeConnection extends Pointer implements Connection {
     public native void disconnect();
 
     @Override
+    public NativeResult execute(String query) {
+        NativeResult result = new NativeResult();
+        NativeExt.execute(result, this, query);
+        return result;
+    }
+
+    @Override
     public NativeResult execute(String query, long timeout) {
         NativeResult result = new NativeResult();
         NativeExt.execute(result, this, query, timeout);
         return result;
+    }
+
+    @Override
+    public NativeStatement prepare(String query) {
+        return NativeStatement.create(this, query);
     }
 
     @Override

--- a/src/main/java/io/nanodbc/impl/NativeExt.java
+++ b/src/main/java/io/nanodbc/impl/NativeExt.java
@@ -12,6 +12,8 @@ class NativeExt {
         Loader.load();
     }
 
+    static native void execute(@ByRef NativeResult result, @ByRef NativeConnection conn, String query);
+
     static native void execute(@ByRef NativeResult result, @ByRef NativeConnection conn, String query, long timeout);
 
     static native void execute(@ByRef NativeResult result, @ByRef NativeStatement statement);

--- a/src/main/java/io/nanodbc/impl/NativeStatement.java
+++ b/src/main/java/io/nanodbc/impl/NativeStatement.java
@@ -30,14 +30,25 @@ class NativeStatement extends Pointer implements Statement {
 
     private final List<Pointer> parameterPointers;
 
-    public static NativeStatement create(NativeConnection connection, String query, long timeout) {
+    static NativeStatement create(NativeConnection connection, String query) {
+        return new NativeStatement(connection, query, new ArrayList<>());
+    }
+
+    static NativeStatement create(NativeConnection connection, String query, long timeout) {
         return new NativeStatement(connection, query, timeout, new ArrayList<>());
     }
 
-    NativeStatement(NativeConnection connection, String query, long timeout, List<Pointer> parameterPointers) {
+    private NativeStatement(NativeConnection connection, String query, List<Pointer> parameterPointers) {
+        allocate(connection, query);
+        this.parameterPointers = parameterPointers;
+    }
+
+    private NativeStatement(NativeConnection connection, String query, long timeout, List<Pointer> parameterPointers) {
         allocate(connection, query, timeout);
         this.parameterPointers = parameterPointers;
     }
+
+    private native void allocate(@ByRef NativeConnection connection, String query);
 
     private native void allocate(@ByRef NativeConnection connection, String query, long timeout);
 


### PR DESCRIPTION
Add variants of `connect`, `execute`, and `prepare` without a timeout parameter, which is assumed to be an infinite timeout.