### PR TITLE
Fix native data type for longs

### DIFF
--- a/src/main/java/io/nanodbc/impl/NativeResult.java
+++ b/src/main/java/io/nanodbc/impl/NativeResult.java
@@ -77,11 +77,11 @@ public class NativeResult extends Pointer implements Result {
     public native int getInt(String columnName);
 
     @Override
-    @Name("get<long>")
+    @Name("get<long long>")
     public native long getLong(short column);
 
     @Override
-    @Name("get<long>")
+    @Name("get<long long>")
     public native long getLong(String columnName);
 
     @Override

--- a/src/main/java/io/nanodbc/impl/NativeStatement.java
+++ b/src/main/java/io/nanodbc/impl/NativeStatement.java
@@ -62,8 +62,8 @@ class NativeStatement extends Pointer implements Statement {
         bind(column, longPointer);
     }
 
-    @Name("bind<long>")
-    private native void bind(short column, @Cast("long*") LongPointer floatPointer);
+    @Name("bind<long long>")
+    private native void bind(short column, LongPointer longPointer);
 
     @Override
     public void bind(short column, float value) {


### PR DESCRIPTION
Use C++ `long long`s to keep the proper precision when dealing with Java `long`s. It turns out C++ `int32_t`s and `longs` have the same range.  See:
* https://docs.microsoft.com/en-us/cpp/c-language/cpp-integer-limits?view=msvc-170
* https://www.geeksforgeeks.org/c-data-types/