### PR TITLE
Improve pointer management

### DIFF
--- a/src/main/java/io/nanodbc/impl/NativeConnection.java
+++ b/src/main/java/io/nanodbc/impl/NativeConnection.java
@@ -58,16 +58,28 @@ public class NativeConnection extends Pointer implements Connection {
 
     @Override
     public NativeResult execute(String query) {
-        NativeResult result = new NativeResult();
-        NativeExt.execute(result, this, query);
-        return result;
+        NativeResult result = null;
+        try {
+            result = new NativeResult();
+            NativeExt.execute(result, this, query);
+            return result;
+        } catch (Exception e) {
+            Pointers.closeQuietly(result);
+            throw e;
+        }
     }
 
     @Override
     public NativeResult execute(String query, long timeout) {
-        NativeResult result = new NativeResult();
-        NativeExt.execute(result, this, query, timeout);
-        return result;
+        NativeResult result = null;
+        try {
+            result = new NativeResult();
+            NativeExt.execute(result, this, query, timeout);
+            return result;
+        } catch (Exception e) {
+            Pointers.closeQuietly(result);
+            throw e;
+        }
     }
 
     @Override

--- a/src/main/java/io/nanodbc/impl/NativeDate.java
+++ b/src/main/java/io/nanodbc/impl/NativeDate.java
@@ -53,11 +53,17 @@ public class NativeDate extends Pointer {
     }
 
     public static NativeDate fromLocalDate(LocalDate localDate) {
-        NativeDate date = new NativeDate();
-        date.setYear(localDate.getYear());
-        date.setMonth(localDate.getMonthValue());
-        date.setDay(localDate.getDayOfMonth());
-        return date;
+        NativeDate date = null;
+        try {
+            date = new NativeDate();
+            date.setYear(localDate.getYear());
+            date.setMonth(localDate.getMonthValue());
+            date.setDay(localDate.getDayOfMonth());
+            return date;
+        } catch (Exception e) {
+            Pointers.closeQuietly(date);
+            throw e;
+        }
     }
 
 }

--- a/src/main/java/io/nanodbc/impl/NativeDateTime.java
+++ b/src/main/java/io/nanodbc/impl/NativeDateTime.java
@@ -85,15 +85,21 @@ public class NativeDateTime extends Pointer {
     }
 
     public static NativeDateTime fromLocalDateTime(LocalDateTime localDateTime) {
-        NativeDateTime dateTime = new NativeDateTime();
-        dateTime.setYear(localDateTime.getYear());
-        dateTime.setMonth(localDateTime.getMonthValue());
-        dateTime.setDay(localDateTime.getDayOfMonth());
-        dateTime.setHour(localDateTime.getHour());
-        dateTime.setMinute(localDateTime.getMinute());
-        dateTime.setSecond(localDateTime.getSecond());
-        dateTime.setFract(localDateTime.getNano() / 100_000);
-        return dateTime;
+        NativeDateTime dateTime = null;
+        try {
+            dateTime = new NativeDateTime();
+            dateTime.setYear(localDateTime.getYear());
+            dateTime.setMonth(localDateTime.getMonthValue());
+            dateTime.setDay(localDateTime.getDayOfMonth());
+            dateTime.setHour(localDateTime.getHour());
+            dateTime.setMinute(localDateTime.getMinute());
+            dateTime.setSecond(localDateTime.getSecond());
+            dateTime.setFract(localDateTime.getNano() / 100_000);
+            return dateTime;
+        } catch (Exception e) {
+            Pointers.closeQuietly(dateTime);
+            throw e;
+        }
     }
 
 }

--- a/src/main/java/io/nanodbc/impl/NativeStatement.java
+++ b/src/main/java/io/nanodbc/impl/NativeStatement.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.BiConsumer;
 
 import org.bytedeco.javacpp.BytePointer;
 import org.bytedeco.javacpp.DoublePointer;
@@ -47,9 +48,7 @@ public class NativeStatement extends Pointer implements Statement {
     public void bind(short column, int value) {
         IntPointer intPointer = new IntPointer(1L);
         intPointer.put(value);
-        Pointer oldPointer = parameterPointers.put(column, intPointer);
-        bind(column, intPointer);
-        close(oldPointer);
+        setParameterPointer(column, intPointer, this::bind);
     }
 
     @Name("bind<int32_t>")
@@ -59,9 +58,7 @@ public class NativeStatement extends Pointer implements Statement {
     public void bind(short column, long value) {
         LongPointer longPointer = new LongPointer(1L);
         longPointer.put(value);
-        Pointer oldPointer = parameterPointers.put(column, longPointer);
-        bind(column, longPointer);
-        close(oldPointer);
+        setParameterPointer(column, longPointer, this::bind);
     }
 
     @Name("bind<long long>")
@@ -71,9 +68,7 @@ public class NativeStatement extends Pointer implements Statement {
     public void bind(short column, float value) {
         FloatPointer floatPointer = new FloatPointer(1L);
         floatPointer.put(value);
-        Pointer oldPointer = parameterPointers.put(column, floatPointer);
-        bind(column, floatPointer);
-        close(oldPointer);
+        setParameterPointer(column, floatPointer, this::bind);
     }
 
     @Name("bind<float>")
@@ -83,9 +78,7 @@ public class NativeStatement extends Pointer implements Statement {
     public void bind(short column, double value) {
         DoublePointer doublePointer = new DoublePointer(1L);
         doublePointer.put(value);
-        Pointer oldPointer = parameterPointers.put(column, doublePointer);
-        bind(column, doublePointer);
-        close(oldPointer);
+        setParameterPointer(column, doublePointer, this::bind);
     }
 
     @Name("bind<double>")
@@ -93,43 +86,31 @@ public class NativeStatement extends Pointer implements Statement {
 
     @Override
     public void bind(short column, String value) {
-        BytePointer bytePointer = new BytePointer(value);
-        Pointer oldPointer = parameterPointers.put(column, bytePointer);
-        bind(column, bytePointer);
-        close(oldPointer);
+        setParameterPointer(column, new BytePointer(value), this::bind);
     }
 
     @Name("bind<::nanodbc::string::value_type>")
     private native void bind(short column, @Cast("::nanodbc::string::value_type*") BytePointer bytePointer);
 
     @Override
-    public void bind(short column, LocalDate date) {
-        NativeDate datePointer = NativeDate.fromLocalDate(date);
-        Pointer oldPointer = parameterPointers.put(column, datePointer);
-        bind(column, datePointer);
-        close(oldPointer);
+    public void bind(short column, LocalDate value) {
+        setParameterPointer(column, NativeDate.fromLocalDate(value), this::bind);
     }
 
     @Name("bind<::nanodbc::date>")
     private native void bind(short column, NativeDate datePointer);
 
     @Override
-    public void bind(short column, LocalTime time) {
-        NativeTime timePointer = NativeTime.fromLocalTime(time);
-        Pointer oldPointer = parameterPointers.put(column, timePointer);
-        bind(column, timePointer);
-        close(oldPointer);
+    public void bind(short column, LocalTime value) {
+        setParameterPointer(column, NativeTime.fromLocalTime(value), this::bind);
     }
 
     @Name("bind<::nanodbc::time>")
     private native void bind(short column, NativeTime timePointer);
 
     @Override
-    public void bind(short column, LocalDateTime dateTime) {
-        NativeDateTime dateTimePointer = NativeDateTime.fromLocalDateTime(dateTime);
-        Pointer oldPointer = parameterPointers.put(column, dateTimePointer);
-        bind(column, dateTimePointer);
-        close(oldPointer);
+    public void bind(short column, LocalDateTime value) {
+        setParameterPointer(column, NativeDateTime.fromLocalDateTime(value), this::bind);
     }
 
     @Name("bind<::nanodbc::timestamp>")
@@ -137,9 +118,11 @@ public class NativeStatement extends Pointer implements Statement {
 
     @Override
     public void bindNull(short column) {
-        Pointer oldPointer = parameterPointers.remove(column);
-        bindNullNative(column);
-        close(oldPointer);
+        try {
+            bindNullNative(column);
+        } finally {
+            Pointers.closeQuietly(parameterPointers.remove(column));
+        }
     }
 
     @Name("bind_null")
@@ -147,9 +130,15 @@ public class NativeStatement extends Pointer implements Statement {
 
     @Override
     public NativeResult execute() {
-        NativeResult result = new NativeResult();
-        NativeExt.execute(result, this);
-        return result;
+        NativeResult result = null;
+        try {
+            result = new NativeResult();
+            NativeExt.execute(result, this);
+            return result;
+        } catch (Exception e) {
+            Pointers.closeQuietly(result);
+            throw e;
+        }
     }
 
     @Override
@@ -160,15 +149,17 @@ public class NativeStatement extends Pointer implements Statement {
     @Override
     public void close() {
         for (Pointer parameterPointer : parameterPointers.values()) {
-            parameterPointer.close();
+            Pointers.closeQuietly(parameterPointer);
         }
         parameterPointers.clear();
         super.close();
     }
 
-    private static void close(Pointer pointer) {
-        if (pointer != null) {
-            pointer.close();
+    private <T extends Pointer> void setParameterPointer(short column, T pointer, BiConsumer<Short, T> binder) {
+        try {
+            binder.accept(column, pointer);
+        } finally {
+            Pointers.closeQuietly(parameterPointers.put(column, pointer));
         }
     }
 

--- a/src/main/java/io/nanodbc/impl/NativeTime.java
+++ b/src/main/java/io/nanodbc/impl/NativeTime.java
@@ -53,11 +53,17 @@ public class NativeTime extends Pointer {
     }
 
     public static NativeTime fromLocalTime(LocalTime localTime) {
-        NativeTime time = new NativeTime();
-        time.setHour(localTime.getHour());
-        time.setMinute(localTime.getMinute());
-        time.setSecond(localTime.getSecond());
-        return time;
+        NativeTime time = null;
+        try {
+            time = new NativeTime();
+            time.setHour(localTime.getHour());
+            time.setMinute(localTime.getMinute());
+            time.setSecond(localTime.getSecond());
+            return time;
+        } catch (Exception e) {
+            Pointers.closeQuietly(time);
+            throw e;
+        }
     }
 
 }

--- a/src/main/java/io/nanodbc/impl/Pointers.java
+++ b/src/main/java/io/nanodbc/impl/Pointers.java
@@ -1,0 +1,21 @@
+package io.nanodbc.impl;
+
+import org.bytedeco.javacpp.Pointer;
+
+public class Pointers {
+
+    public static void closeQuietly(Pointer pointer) {
+        try {
+            if (pointer != null) {
+                pointer.close();
+            }
+        } catch (Exception e) {
+            // swallow
+        }
+    }
+
+    private Pointers() {
+        // utility class
+    }
+
+}


### PR DESCRIPTION
Instead of keeping all pointers created for parameters in the lifetime of a statement, index them by bind position and release old pointers when a new value is bound.

Also includes major changes to free pointers to objects created that were leaked when exceptions were thrown.

Fixes #35 