### PR TITLE
Fix AppVeyor publish build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ artifacts:
     name: jar
 
 deploy_script:
-  - if "%APPVEYOR_REPO_TAG%"=="true" (gradlew.bat publish -xprocessJavacpp)
+  - if "%APPVEYOR_REPO_TAG%"=="true" (gradlew.bat publish -xcompileJavacpp)
 
 cache:
   - C:\Users\appveyor\.gradle


### PR DESCRIPTION
Task name was changed from `processJavacpp` to `compileJavacpp` in #34 