### PR TITLE
Disable unsafe string function compiler warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,8 @@ task compileJavacpp(type: JavaExec) {
     '-Xcompiler', 'odbc32.lib',
     '-Xcompiler', 'odbccp32.lib',
     '-Xcompiler', "/I${nanodbcSrcPath}",
-    '-Xcompiler', "/I${nanodbcExtSrcPath}"
+    '-Xcompiler', "/I${nanodbcExtSrcPath}",
+    '-Xcompiler', '/D_CRT_SECURE_NO_WARNINGS'
   ]
 }
 


### PR DESCRIPTION
Disable compiler warnings in code generated by JavaCPP.

Example:

```
C:\projects\nanodbc-java\build\classes\java\main\jnijavacpp.cpp(1617): warning C4996: 'strcpy': This function or variable may be unsafe. Consider using strcpy_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
```